### PR TITLE
Revamp Projects/Research pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,58 @@ docker run --rm -v "$PWD:/srv/jekyll" \
            jekyll serve --livereload
 ```
 
+## Guide to Making Changes to the Website
+
+### Adding a Project to /projects/ directory on the Website
+
+It is possible to 
+
+- add a new page with a lot of project details (e.g.,
+`\_pages\testproject.md`) and then add the project excerpt to the projects
+directory `_data\projects.yml`, or 
+
+- you can simply add the project excerpt to the projects directory
+`_data\projects.yml` if there aren't enough details available for the project.
+
+Next, use the `link` attribute in the `projects.yml` file to define the link
+to the detailed project page (if you created this in the previous step).
+
+Next, look at the values in the `category` field in the `_data\projects.yml`
+file. This represents the "Areas of Research", that are also explained on the
+`/research/` page. If the category you're looking for already exists, then use
+the respective value in the category field. If not, there is one additional
+step that is required for the projects belonging to this category to show up
+on the Projects page:
+
+To populate a new category on the projects page, enter the following snippet
+using your new Research Area's name instead of 'LOREM_IPSUM':
+
+```
+## Research Area: LOREM_IPSUM
+
+{% for project in site.data.projects %}
+  {% if project.category == "LOREM_IPSUM" %}
+
+### {{ project.name }}
+
+{{ project.description | markdownify }}
+
+For more details, please browse to this <a href="{{ project.link }}">link to the project</a>
+
+{% endif %}
+{% endfor %}
+```
+
+The project excerpt should now automatically show up on the '/Projects/' page
+along with the link to the detailed project page.
+
+To change the layout of the Projects page itself, you can browse to
+`_pages\projects.md` and edit the Liquid code as needed.
+
+> Please note that the Projects page exists in parallel to the Open Projects
+> page (`_pages\open_projects.md`), and you should add your project details
+> where it makes more sense.
+
 
 [installation]: https://jekyllrb.com/docs/installation/windows/
 [RubyInstaller Downloads]: https://rubyinstaller.org/downloads/

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,0 +1,74 @@
+- name: "C++ Language Interoperability Layer"
+  description: |
+    In the CppInterOp (previously LibInterOp) project, we explore the key aspects
+    of language interoperability with C++ using an automated binding approach,
+    focusing on automatic binding to and from Python, but also applicable to other
+    languages like D and Julia. 
+
+  category: "Language Interoperability"
+  link: |
+      https://compiler-research.org/libinterop/
+
+- name: "Clad"
+  description: |
+    Clad is a plugin for the Clang compiler that enables automatic differentiation
+    capabilities for C/C++ codebases. It is a valuable tool for developers seeking
+    to streamline complex mathematical computations and optimize their codebase
+    efficiently.
+
+    Clad facilitates the generation of derivatives, gradients, Hessians, and
+    Jacobians (in forward and/or reverse mode), enhancing the efficiency and
+    versatility of numerical computations.
+
+    Clad not only supports partial and higher-order derivatives but also
+    integrates seamlessly with frameworks like ROOT, providing a comprehensive
+    solution for automatic differentiation needs in C++ applications.
+  category: "Automatic Differentiation"
+  link: |
+    https://compiler-research.org/clad/
+
+- name: "Vectorized Automatic Differentiation (Clad Use Case)"
+  description: |
+    Vectorized Automatic Differentiation in C++ is a powerful technique that
+    enables the automatic computation of derivatives for mathematical functions.
+  category: "Automatic Differentiation"
+  link: |
+    https://compiler-research.org/vectorautodiff/
+
+- name: "Cling"
+  description: |
+    Cling is an interactive C++ interpreter that operates on top of the Clang and
+    LLVM libraries, utilizing LLVM's Just-In-Time (JIT) compiler for fast and
+    optimized compilation processes. 
+
+    By adopting a read-eval-print-loop (REPL) approach, Cling is helping C++
+    development evolve by enabling rapid application development without the need
+    for the traditional edit-compile-run-debug cycle, thus facilitating quick
+    prototyping and exploration in C++.
+
+    By providing support for advanced C++ features like templates, lambdas, and
+    virtual inheritance, Cling empowers developers in exploratory programming with
+    interactive, dynamic language interoperability and rapid prototyping.
+  category: "Interactive C++"
+  link: |
+    https://rawgit.com/root-project/cling/master/www/index.html
+
+- name: "Interactive C++ (Cling Use Case)"
+  description: |
+    Researchers heavily rely on tools that minimize the "time to insight" to
+    enhance productivity. However, the escalating data volumes and computational
+    demands necessitate a constant emphasis on optimizing code performance. This
+    is where interactive capabilities of tools like Cling are useful, enabling
+    navigation through a diverse set of programming languages, development tools,
+    and hardware.
+  category: "Interactive C++"
+  link: |
+    https://compiler-research.org/interactive_cpp
+
+- name: "Incremental Compilation Support in Clang (CaaS) Project"
+  description: |
+    Incremental compilation aims to support clients that need to keep a single 
+    compiler instance active across multiple compile requests. 
+  category: "Compiler-As-A-Service"
+  link: |
+    https://compiler-research.org/caas/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,14 +12,14 @@
       </a>
     </div>
     <ul id="navbar-collapse-1" class="nav navbar-nav ml-auto navbar-collapse collapse">
-      <li class="nav-item dropdown">
+<!--      <li class="nav-item dropdown">
         <a href="#" class="nav-link dropdown-toggle" id="dropdown02" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Research</a>
         <ul class="dropdown-menu" aria-labelledby="dropdown02">
           <li class="dropdown-item"> <a class="nav-link" href="/caas">Compiler-As-A-Service</a></li>
           <li class="dropdown-item"> <a class="nav-link" href="/interactive_cpp">Incremental C++</a></li>
           <li class="dropdown-item"> <a class="nav-link" href="/libinterop">Language Interoperability</a></li>
         </ul>
-      </li>
+      </li> 
       <li class="nav-item dropdown">
         <a href="#" class="nav-link dropdown-toggle" id="dropdown02" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Projects</a>
         <ul class="dropdown-menu" aria-labelledby="dropdown02">
@@ -27,6 +27,12 @@
           <li class="dropdown-item"> <a class="nav-link" href="/clad">Clad</a></li>
           <li class="dropdown-item"> <a class="nav-link" href="/vectorautodiff/">Vectorized Automatic Differentiation</a></li>
         </ul>
+      </li>-->
+      <li class="nav-item">
+        <a class="nav-link" href="/research">Research</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/projects">Projects</a>
       </li>
       <li class="nav-item dropdown">
         <a href="#" class="nav-link dropdown-toggle" id="dropdown01" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Results</a>

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,0 +1,83 @@
+---
+title: "Compiler Research Projects"
+layout: gridlay
+excerpt: "Notable Projects by Compiler Research Group"
+sitemap: false
+permalink: /projects/
+---
+
+<nav>
+  <h4>Table of Contents</h4>
+  * this unordered seed list will be replaced by toc as unordered list
+  {:toc}
+</nav>
+
+---
+
+Following are some notable projects, organized based on the [Area of Research]
+that they belong to.
+
+
+## Automatic Differentiation
+
+{% for project in site.data.projects %}
+  {% if project.category == "Automatic Differentiation" %}
+
+### {{ project.name }}
+
+{{ project.description | markdownify }}
+
+For more details, please browse to this <a href="{{ project.link }}">link to the project</a>
+
+{% endif %}
+{% endfor %}
+
+---
+
+## Compiler-As-A-Service
+
+{% for project in site.data.projects %}
+  {% if project.category == "Compiler-As-A-Service" %}
+
+### {{ project.name }}
+
+{{ project.description | markdownify }}
+
+For more details, please browse to this <a href="{{ project.link }}">link to the project</a>
+
+{% endif %}
+{% endfor %}
+
+---
+
+## Interactive C++
+
+{% for project in site.data.projects %}
+  {% if project.category == "Interactive C++" %}
+
+### {{ project.name }}
+
+{{ project.description | markdownify }}
+
+For more details, please browse to this <a href="{{ project.link }}">link to the project</a>
+
+{% endif %}
+{% endfor %}
+
+---
+
+## Language Interoperability
+
+{% for project in site.data.projects %}
+  {% if project.category == "Language Interoperability" %}
+
+### {{ project.name }}
+
+{{ project.description | markdownify }}
+
+For more details, please browse to this <a href="{{ project.link }}">link to the project</a>
+
+{% endif %}
+{% endfor %}
+
+[Area of Research]: https://compiler-research.org/research/

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,0 +1,102 @@
+---
+title: "Compiler Research Research Areas"
+layout: gridlay
+excerpt: "Research"
+sitemap: false
+permalink: /research/
+---
+
+Following are the areas of research that Compiler Research Group is focused on:
+
+### Automatic Differentiation
+
+Automatic Differentiation (AD) is a useful technique in scientific research
+fields like machine learning and computational physics. AD enables the
+automatic computation of derivatives of functions with high precision and
+efficiency. A notable implementation of AD is the Clad plugin for the Clang
+compiler. This integration not only simplifies the process of differentiation
+but also enhances the performance and accuracy of numerical computations in
+scientific applications.
+
+In scientific research, where intricate mathematical models are prevalent, the
+utilization of AD through tools like the Clad brings a new level of
+sophistication and speed to derivative calculations. By leveraging AD within
+C++ compilers, researchers can focus more on the scientific aspects of their
+work rather than getting bogged down in manual differentiation tasks. This
+automation not only accelerates the development process but also ensures that
+computations are error-free and consistent.
+
+### Compiler-As-A-Service
+
+Compiler as a Service (CaaS) is an evolving technology that redefines the
+traditional approach to compilers by providing a service-oriented
+architecture. Instead of treating the compiler as a black box, the CaaS
+approach helps open up the functionality to make it available as APIs. This
+gives developers unprecedented control and insights into the compilation
+process, while being able to use lightweight APIs for simpler workflows and
+diagnostics, helping create sophisticated applications more efficiently.
+
+Practical applications of CaaS include deeper and interactive program analysis
+and conversion from one programming language to another (e.g., C++ <->
+Python).
+
+
+### Incremental C++
+
+Despite its high performance capabilities, C++ not the first programming
+language that comes to mind for rapidly developing robust applications, mainly
+due to the long edit-compile-run cycles.
+
+Ongoing research in projects such as Cling, Clang-REPL, etc. aims to provide
+practically usable interactive capabilities to the C++ programming language.
+The goal is to enable dynamic interoperability, rapid prototyping, and
+exploratory programming, which are essential for data science and other
+scientific applications.
+
+Following are some practical applications of a "C++ Interpreter," so to speak:
+
+- In Data Science: Interactive probing of data and interfaces, making complex
+  libraries and data more accessible to users. [^1]
+
+- In CUDA: The Cling CUDA extension brings the workflows of interactive C++ to
+  GPUs without losing performance and compatibility to existing software. [^1]
+
+- In Exploratory Programming: rapid reproduction of results, which is crucial
+  during the exploratory phase of a project. [^2]
+
+- In Jupyter Notebooks: Interactive C++ can be integrated with Jupyter
+  Notebooks, providing a swift prototyping and learning experience for C++ users. [^2]
+
+### Language Interoperability
+
+Language interoperability helps programmers get the best of both worlds, with
+the ability to work with a high-performance language (e.g., C++), and at the
+same time, take advantage of a more interactive one (e.g., Python), while
+helping them identify each other's entities (like variables and classes) for
+seamless integration.
+
+This interoperability can be achieved by libraries like CppInterOp[^3], which
+expose APIs from compilers like Clang/LLVM in a backward-compatible manner. By
+enabling interactive C++ usage through the Compiler-As-A-Service, CppInterOp
+simplifies complex tasks such as "language interoperability on the fly".
+
+The practical implications of language interoperability include the growing
+need for systems in data science to be able to interoperate with C++
+codebases[^4]. By providing automatic creation of bindings on demand, tools
+like CppInterOp enable Python to interoperate with C++ code dynamically,
+instantiate templates, and execute them efficiently. This dynamic approach not
+only improves performance but also simplifies code development and debugging
+processes, offering a more efficient alternative to static binding methods.
+
+---
+
+#### Footnotes:
+
+[^1]: [Interactive C++ for Data Science](https://blog.llvm.org/posts/2020-12-21-interactive-cpp-for-data-science/)
+
+[^2]: [Interactive Workflows for C++ with Jupyter](https://blog.jupyter.org/interactive-workflows-for-c-with-jupyter-fe9b54227d92)
+
+
+[^3]: [CppInterOp ReadMe](https://github.com/compiler-research/CppInterOp/blob/main/README.md)
+
+[^4]: [C++ Language Interoperability Layer](https://compiler-research.org/libinterop/)


### PR DESCRIPTION
- Created writeup for a static **Research Page**

- Removed Menu items under **Research** and added them as **sub-projects on Projects page**

- Added unique writeups for project summaries in projects.yml

- removed menu items from under **projects menu**

- created a **projects.md** page, to pull project excerpts from **projects.yml**

- linked existing detailed project pages (e.g., vetorautodiff) within projects.yml, to ultimately show on the projects page

- **projects.md**: looped through projects to filter them based on the respective Research Area (category attribute in projects.yml) and displayed relevant projects under respective Research Area heading in project.md page

- added a step-by-step tutorial in readme for future site contributors to be able to add more projects to the website (this tutorial section will grow as the site revamp continues)

- Unused code (drop-downs for Research and Projects menu items) is now commented in the header file

- Images of resultant pages are attached for reference:

- **Research** (static page)

<img width="960" alt="RESEARCH" src="https://github.com/compiler-research/compiler-research.github.io/assets/130300172/e7b02bc6-8334-43ea-aa49-969a6d0c3fae">

- **Projects** (dynamically generated)

<img width="960" alt="PROJECTS" src="https://github.com/compiler-research/compiler-research.github.io/assets/130300172/11fc3d67-9e84-4a07-9f80-67751e01eab4">
