### PR TITLE
Add authors to all blog posts

### DIFF
--- a/_posts/2022-11-30-extend-clang-to-resugar-template-specialization-accesses.md
+++ b/_posts/2022-11-30-extend-clang-to-resugar-template-specialization-accesses.md
@@ -13,6 +13,7 @@ excerpt: "Clang is an LLVM native C/C++/Objective-C compiler, which aims to
    This leads to many infamous pathological errors which have haunted C++ 
    developers for decades."
 sitemap: false
+author: Matheus Izvekov
 permalink: blogs/gsoc22_izvekov_experience_blog/
 date: 2022-11-30
 ---

--- a/_posts/2022-12-02-recovering-from-errors-in-clang-repl-and-code-undo.md
+++ b/_posts/2022-12-02-recovering-from-errors-in-clang-repl-and-code-undo.md
@@ -15,6 +15,7 @@ declaration that isn’t a declaration or or specialization of anything
 belongs to the active PTU. However, in case of a template specialization, 
 it can be pulled into a more recent PTU by its template arguments."
 sitemap: false
+author: "Jun Zhang, Purva Chaudhari"
 permalink: blogs/gsoc22_zhang_chaudhari_experience_blog/
 date: 2022-12-02
 ---

--- a/_posts/2022-12-07-shared-memory-based-jitlink-memory-manager.md
+++ b/_posts/2022-12-07-shared-memory-based-jitlink-memory-manager.md
@@ -11,6 +11,7 @@ controller process invokes RPCs in the target or executor process to allocate
 memory and then when the code is generated, all the section contents are
 transferred through finalize calls."
 sitemap: false
+author: Anubhab Ghosh
 permalink: blogs/gsoc22_ghosh_experience_blog/
 date: 2022-12-07
 ---

--- a/_posts/2023-05-10-accelerated-documentation-with-google-season-of-docs-2023.md
+++ b/_posts/2023-05-10-accelerated-documentation-with-google-season-of-docs-2023.md
@@ -8,6 +8,7 @@ Automatic Differentiation applications (using Clad, e.g. in RooFit and
 Floating-Point Error Estimation), and Python-C++ Interoperability (Clang-Repl 
 (LLVM), CppInterOp, cppyy, Numba, etc.)."
 sitemap: false
+author: QuillPusher (Saqib)
 permalink: blogs/gsod23_quillpusher_experience_blog/
 date: 2023-05-10
 ---

--- a/_posts/2023-09-18-code-completion-in-clang-repl.md
+++ b/_posts/2023-09-18-code-completion-in-clang-repl.md
@@ -9,6 +9,7 @@ completing user input or code completion. Sometimes, C++ can be quite wordy,
 requiring users to type every character of an expression or
 statement. Consequently, this causes typos or syntactic errors."
 sitemap: false
+author: Yuquan (Fred) Fu
 permalink: blogs/gsoc23_ffu_experience_blog/
 date: 2023-09-18
 ---


### PR DESCRIPTION
fixes #190 

![image](https://github.com/compiler-research/compiler-research.github.io/assets/108579856/59f4ef9d-6ea1-4194-9262-6dc98931c6cf)

![image](https://github.com/compiler-research/compiler-research.github.io/assets/108579856/534d4861-c43c-4c7d-8517-e02498772508)


Above are some examples, all blogs are done in the exact same way.