### PR TITLE
Add Tags to blog posts

### DIFF
--- a/_includes/blog-post-card.html
+++ b/_includes/blog-post-card.html
@@ -1,0 +1,46 @@
+
+  <div class="well">
+    <h3>{{ post.title }}</h3>
+    <p>
+      {% if post.author %}
+      {% for author_name in post.author %}
+        {% assign author = site.data.contributors | where: "name", author_name | first %}
+        {% if author %}
+        <a href="{{ author.name | replace: " ", "" | prepend: "/team/" }}">
+          <img
+            src="{% if author.photo %}{{ site.baseurl }}/images/team/{{ author.photo }}{% else %}{{ site.baseurl }}/images/team/defaultDP.png{% endif %}"
+            alt="{{ author.name }}" style="
+              width: 30px;
+              height: 30px;
+              border-radius: 50%;
+              margin: 0;
+              margin-top: 4px;
+              margin-bottom: 4px;
+            " />
+          {{ author.name }}
+        </a>
+        {% if forloop.last == false %}, {% endif %}
+        {% else %}
+        {{ author_name }}
+        {% endif %}
+      {% endfor %}
+      {% endif %}
+      <span class="text-muted">
+        • {{ post.date | date: "%b %d, %Y" }} • {{ post.content | number_of_words | divided_by: 200 | ceil }} min read
+      </span>
+    </p>
+    <p>{{ post.excerpt | truncatewords: 50 }}</p>
+
+
+    {% if post.tags and post.tags.size > 0 %}
+    <p>
+      {% for tag in post.tags %}
+      <a href="{{ site.baseurl }}/tags#{{ tag | downcase | slugify }}" class="badge" style="background-color: #999999; padding: 0.5rem">{{ tag }}</a>
+      {% endfor %}
+    </p>
+    {% endif %}
+
+    <p>
+      <button class="btn btn-primary" onclick="window.location.href='{{ post.url }}'">Read More</button>
+    </p>
+  </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -6,47 +6,5 @@ title: Blog
 <h2>Latest Posts</h2>
 
 <div>
-  {% for post in site.posts %}
-  <div class="well">
-    <h3>{{ post.title }}</h3>
-    <p>
-      {% assign author = site.data.contributors | where: "name", post.author | first %}
-      {% if author %}
-      <a href="{{ author.name | replace: " ", "" | prepend: "/team/" }}">
-        <img
-          src="{% if author.photo %}{{ site.baseurl }}/images/team/{{ author.photo }}{% else %}{{ site.baseurl }}/images/team/defaultDP.png{% endif %}"
-          alt="{{ author.name }}" style="
-            width: 30px;
-            height: 30px;
-            border-radius: 50%;
-            /* vertical-align: middle; */
-            margin: 0;
-            margin-top: 4px;
-            margin-bottom: 4px;
-          " />
-        {{ author.name }}
-      </a>
-      {% else %}
-      {{ post.author }}
-      {% endif %}
-      <span class="text-muted">
-        • {{ post.date | date: "%b %d, %Y" }} • {{ post.content | number_of_words | divided_by: 200 | ceil }} min read
-      </span>
-    </p>
-    <p>{{ post.excerpt | truncatewords: 50 }}</p>
-
-
-    {% if post.tags and post.tags.size > 0 %}
-    <p>
-      {% for tag in post.tags %}
-      <a href="{{ site.baseurl }}/tags#{{ tag | downcase | slugify }}" class="badge" style="background-color: #999999; padding: 0.5rem">{{ tag }}</a>
-      {% endfor %}
-    </p>
-    {% endif %}
-
-    <p>
-      <button class="btn btn-primary" onclick="window.location.href='{{ post.url }}'">Read More</button>
-    </p>
-  </div>
-  {% endfor %}
+  {% for post in site.posts %} {% include blog-post-card.html %} {% endfor %}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -33,4 +33,21 @@ layout: default
   </header>
 
   <div class="post-content" itemprop="articleBody">{{ content }}</div>
+
+  {% if page.tags and page.tags.size > 0 %}
+  <hr />
+  <footer class="post-footer">
+    <p>
+      <h4>Tags:</h4>
+      {% for tag in page.tags %}
+      <a
+        href="{{ site.baseurl }}/tag#{{ tag | downcase | slugify }}"
+        class="badge badge-secondary"
+        style="background-color: #999999; padding: 0.5rem"
+        >{{ tag }}</a
+      >
+      {% endfor %}
+    </p>
+  </footer>
+  {% endif %}
 </article>

--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -7,55 +7,13 @@ title: Tags
 
 <div>
   {% for tag in site.tags %} {% assign t = tag | first %} {% assign posts = tag
-  | last %} 
+  | last %}
 
-  <h3 id={{t | downcase}}>
-    {{ t | downcase }}
-  </h3>
+  <h3 id="{{ t | downcase }}">{{ t | downcase }}</h3>
   <div>
-    {% for post in posts %} {% if post.tags contains t %}
-  <div class="well">
-    <h3>{{ post.title }}</h3>
-    <p>
-      {% assign author = site.data.contributors | where: "name", post.author | first %}
-      {% if author %}
-      <a href="{{ author.name | replace: " ", "" | prepend: " /team/" }}">
-        <img
-          src="{% if author.photo %}{{ site.baseurl }}/images/team/{{ author.photo }}{% else %}{{ site.baseurl }}/images/team/defaultDP.png{% endif %}"
-          alt="{{ author.name }}" style="
-            width: 30px;
-            height: 30px;
-            border-radius: 50%;
-            /* vertical-align: middle; */
-	    margin: 0;
-	    margin-top: 4px;
-	    margin-bottom: 4px;
-          " />
-        {{ author.name }}
-      </a>
-      {% else %}
-      {{ post.author }}
-      {% endif %}
-      <span class="text-muted">
-        • {{ post.date | date: "%b %d, %Y" }} • {{ post.content | number_of_words | divided_by: 200 | ceil }} min read
-      </span>
-    </p>
-    <p>{{ post.excerpt | truncatewords: 50 }}</p>
-
-    {% if post.tags and post.tags.size > 0 %}
-    <p>
-      {% for tag in post.tags %}
-      <a href="{{ site.baseurl }}/tags#{{ tag | downcase | slugify }}" class="badge" style="background-color: #999999; padding: 0.5rem">{{ tag }}</a>
-      {% endfor %}
-    </p>
-    {% endif %}
-
-
-    <p>
-      <button class="btn btn-primary" onclick="window.location.href='{{ post.url }}'">Read More</button>
-    </p>
+    {% for post in posts %} {% if post.tags contains t %} {% include
+    blog-post-card.html post=post %} {% endif %} {% endfor %}
   </div>
-    {% endif %} {% endfor %}
-  </div>
+  <hr />
   {% endfor %}
 </div>

--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -1,18 +1,25 @@
 ---
 layout: default
-title: Blog
+title: Tags
 ---
 
-<h2>Latest Posts</h2>
+<h2>Tags</h2>
 
 <div>
-  {% for post in site.posts %}
+  {% for tag in site.tags %} {% assign t = tag | first %} {% assign posts = tag
+  | last %} 
+
+  <h3 id={{t | downcase}}>
+    {{ t | downcase }}
+  </h3>
+  <div>
+    {% for post in posts %} {% if post.tags contains t %}
   <div class="well">
     <h3>{{ post.title }}</h3>
     <p>
       {% assign author = site.data.contributors | where: "name", post.author | first %}
       {% if author %}
-      <a href="{{ author.name | replace: " ", "" | prepend: "/team/" }}">
+      <a href="{{ author.name | replace: " ", "" | prepend: " /team/" }}">
         <img
           src="{% if author.photo %}{{ site.baseurl }}/images/team/{{ author.photo }}{% else %}{{ site.baseurl }}/images/team/defaultDP.png{% endif %}"
           alt="{{ author.name }}" style="
@@ -20,9 +27,9 @@ title: Blog
             height: 30px;
             border-radius: 50%;
             /* vertical-align: middle; */
-            margin: 0;
-            margin-top: 4px;
-            margin-bottom: 4px;
+	    margin: 0;
+	    margin-top: 4px;
+	    margin-bottom: 4px;
           " />
         {{ author.name }}
       </a>
@@ -35,7 +42,6 @@ title: Blog
     </p>
     <p>{{ post.excerpt | truncatewords: 50 }}</p>
 
-
     {% if post.tags and post.tags.size > 0 %}
     <p>
       {% for tag in post.tags %}
@@ -44,9 +50,12 @@ title: Blog
     </p>
     {% endif %}
 
+
     <p>
       <button class="btn btn-primary" onclick="window.location.href='{{ post.url }}'">Read More</button>
     </p>
+  </div>
+    {% endif %} {% endfor %}
   </div>
   {% endfor %}
 </div>

--- a/_pages/tags.md
+++ b/_pages/tags.md
@@ -1,0 +1,11 @@
+---
+title: "Tags"
+layout: tags
+excerpt: "Tags"
+sitemap: false
+permalink: /tags/
+---
+
+<div id="textid" class="col-sm-12">
+  {{ content }}
+</div>

--- a/_posts/2022-11-30-extend-clang-to-resugar-template-specialization-accesses.md
+++ b/_posts/2022-11-30-extend-clang-to-resugar-template-specialization-accesses.md
@@ -16,6 +16,7 @@ sitemap: false
 author: Matheus Izvekov
 permalink: blogs/gsoc22_izvekov_experience_blog/
 date: 2022-11-30
+tags: gsoc clang llvm
 ---
 
 ### Overview of the Project
@@ -61,7 +62,6 @@ naming context, without the need of tracking the template context. This
 approach, although more efficient, required some intrusive modifications on the
 way substitutions are represented in the AST.
 
-
 ### Contributions
 
 The main contributions to this project are listed here.
@@ -78,7 +78,6 @@ Pull Requests:
 6. [D130308 - Extend getCommonSugaredType to merge sugar nodes](https://reviews.llvm.org/D130308)
 7. [D131858 - Track the templated entity in type substitution](https://reviews.llvm.org/D131858)
 8. [D127695 - Implement Template Specialization Resugaring](https://reviews.llvm.org/D127695)
-
 
 ### Contributions
 
@@ -98,7 +97,6 @@ system. This issue often prevents successful resugaring in C++. Improving the
 type rules for syntactic sugar in STL will reduce the generation of errors in
 terms of desugared code, improving the relationship between the user's source
 program and the program evaluation.
-
 
 ### Acknowledgements
 
@@ -120,7 +118,7 @@ increase my confidence as a developer in the LLVM open community!
 
 **Contact me!**
 
-Email: mizvekov@gmail.com
+Email: <mizvekov@gmail.com>
 
 Github Username: [mizvekov](https://github.com/mizvekov)
 

--- a/_posts/2022-11-30-extend-clang-to-resugar-template-specialization-accesses.md
+++ b/_posts/2022-11-30-extend-clang-to-resugar-template-specialization-accesses.md
@@ -118,7 +118,7 @@ increase my confidence as a developer in the LLVM open community!
 
 **Contact me!**
 
-Email: <mizvekov@gmail.com>
+Email: [mizvekov@gmail.com](/team/MatheusIzvekov)
 
 Github Username: [mizvekov](https://github.com/mizvekov)
 

--- a/_posts/2022-11-30-extend-clang-to-resugar-template-specialization-accesses.md
+++ b/_posts/2022-11-30-extend-clang-to-resugar-template-specialization-accesses.md
@@ -118,7 +118,7 @@ increase my confidence as a developer in the LLVM open community!
 
 **Contact me!**
 
-Email: [mizvekov@gmail.com](/team/MatheusIzvekov)
+Email: mizvekov@gmail.com
 
 Github Username: [mizvekov](https://github.com/mizvekov)
 

--- a/_posts/2022-12-02-recovering-from-errors-in-clang-repl-and-code-undo.md
+++ b/_posts/2022-12-02-recovering-from-errors-in-clang-repl-and-code-undo.md
@@ -157,7 +157,7 @@ In the future, I'll continue my journey into the world of open source, and bring
 
 **Contact us!**
 
-Jun: <jun@junz.org>
+Jun: [jun@junz.org](/team/JunZhang/)
 
 GitHub username: [junaire](https://github.com/junaire)
 

--- a/_posts/2022-12-02-recovering-from-errors-in-clang-repl-and-code-undo.md
+++ b/_posts/2022-12-02-recovering-from-errors-in-clang-repl-and-code-undo.md
@@ -20,6 +20,7 @@ author:
 - Purva Chaudhari
 permalink: blogs/gsoc22_zhang_chaudhari_experience_blog/
 date: 2022-12-02
+tags: gsoc clang llvm
 ---
 
 ### Overview of the Project
@@ -57,6 +58,7 @@ clang-repl: /home/purva/llvm-project/clang/include/clang/Sema/Sema.h:9406: clang
 Aborted
  (core dumped)
 ```
+
 and
 
 ```cpp
@@ -74,11 +76,9 @@ clang-repl> %undo
 clang-repl> float x = 24 // not an error
 ```
 
-
 ### Contributions
 
 The main contributions to this project are listed here.
-
 
 Pull Requests:
 
@@ -101,29 +101,37 @@ Pull Requests:
 extends the functionality used to recover from errors and adds functionality to
 recover the low-level execution infrastructure. Now you can do below in
 clang-repl:
+
 ```cpp
 clang-repl> int x = 42;
 clang-repl> %undo
 clang-repl> float x = 24; // not an error
 ```
+
 2. We fixed a bunch of bugs in Clang-Repl, by upstreamed ready-made patches in
 cling: Fix inline function in Clang-Repl. Take the example below:
+
 ```cpp
 inline int foo() { return 42; }
 int r3 = foo(); // This fails before my fix.
 ```
+
 More context: [cd64a427](https://github.com/llvm/llvm-project/commit/cd64a427efa0baaf1bb7ae624d4301908afc07f7)
 3. Partially fix incorrect return code in Clang-Repl. Take the example below:
+
 ```cpp
 clang-repl> BOOM!
 clang-repl> int x = 42;
 // This previously passed in the LLVM lit tests incorrectly
 ```
+
 4. Partially fix weak attribute usage in Clang-Repl. Take the example below:
+
 ```cpp
 int __attribute__((weak)) bar() { return 42; }
 auto r4 = printf("bar() = %d\n", bar()); // This fails before my patch. Note this is not supported in Windows yet.
 ```
+
 5. We fixed some issues in lambda usage in Clang-Repl.
 
 ### Conclusion
@@ -149,10 +157,9 @@ In the future, I'll continue my journey into the world of open source, and bring
 
 **Contact us!**
 
-Jun: jun@junz.org
+Jun: <jun@junz.org>
 
 GitHub username: [junaire](https://github.com/junaire)
-
 
 Purva: [Webpage](https://purva-chaudhari.github.io/My-Portfolio/)
 

--- a/_posts/2022-12-02-recovering-from-errors-in-clang-repl-and-code-undo.md
+++ b/_posts/2022-12-02-recovering-from-errors-in-clang-repl-and-code-undo.md
@@ -157,7 +157,7 @@ In the future, I'll continue my journey into the world of open source, and bring
 
 **Contact us!**
 
-Jun: [jun@junz.org](/team/JunZhang/)
+Jun: jun@junz.org
 
 GitHub username: [junaire](https://github.com/junaire)
 

--- a/_posts/2022-12-07-shared-memory-based-jitlink-memory-manager.md
+++ b/_posts/2022-12-07-shared-memory-based-jitlink-memory-manager.md
@@ -166,7 +166,7 @@ many applications.
 
 **Contact me!**
 
-Email: [anubhabghosh.me@gmail.com](/team/AnubhabGhosh)
+Email: anubhabghosh.me@gmail.com
 
 Github Username: [argentite](https://github.com/argentite)
 

--- a/_posts/2022-12-07-shared-memory-based-jitlink-memory-manager.md
+++ b/_posts/2022-12-07-shared-memory-based-jitlink-memory-manager.md
@@ -14,9 +14,11 @@ sitemap: false
 author: Anubhab Ghosh
 permalink: blogs/gsoc22_ghosh_experience_blog/
 date: 2022-12-07
+tags: gsoc llvm jitlink memory-manager
 ---
 
 ### Overview of the Project
+
 LLVM JIT APIs include JITLink, a just-in-time linker that links together objects
 code units directly in memory and executes them. It uses the
 JITLinkMemoryManager interface to allocate and manage memory for the generated
@@ -28,6 +30,7 @@ memory and then when the code is generated, all the section contents are
 transferred through finalize calls.
 
 #### Shared Memory
+
 The main problem was that EPC runs on top of file descriptor streams like Unix
 pipes or TCP sockets. As all the generated code and data bytes are transferred
 over the EPC this has some overhead that could be avoided by using shared
@@ -35,6 +38,7 @@ memory. If the two processes share the same physical memory pages then we can
 completely avoid extra memory copying.
 
 #### Small code model
+
 While we are at it, another goal was to introduce a simple slab-based memory
 manager. It would allocate a large chunk of memory in the beginning from the
 executor process and allocate smaller blocks from that entirely at the
@@ -53,16 +57,20 @@ int main() {
     return value + 1;
 }
 ```
+
 **Small code model**
+
 ```asm
 0000000000001119 <main>:
-    1119: 55               	push rbp
-    111a: 48 89 e5         	mov  rbp,rsp
-    111d: 8b 05 ed 2e 00 00	mov  eax,DWORD PTR [rip+0x2eed] # 4010 <value>
-    1123: 5d               	pop  rbp
-    1124: c3               	ret
+    1119: 55                push rbp
+    111a: 48 89 e5          mov  rbp,rsp
+    111d: 8b 05 ed 2e 00 00 mov  eax,DWORD PTR [rip+0x2eed] # 4010 <value>
+    1123: 5d                pop  rbp
+    1124: c3                ret
 ```
+
 **Large code model**
+
 ```asm
 0000000000001119 <main>:
     1119: 55                    push   rbp
@@ -81,10 +89,10 @@ int main() {
 Small code model is the default for most compilations so this is actually
 required to load ordinary precompiled code, e.g., from existing static archives.
 
-
 ### My Approach
 
 #### Memory Mappers
+
 I introduced a new `MemoryMapper` abstraction for interacting with OS APIs at
 different situations. It has separate implementations based on whether the code
 will be executed in the same or different process. The `InProcessMemoryMapper`
@@ -102,6 +110,7 @@ now already in place in the executor processes so finalization is just a matter
 of sending the memory protections.
 
 #### Slab-based allocator
+
 Furthermore, I developed a slab-based memory allocator for JITLink, reserving a
 large region of memory in the address space of the target process on the first
 allocation. All subsequent allocations result in sub-regions of that to be
@@ -111,6 +120,7 @@ region, it also guarantees that JIT’d memory satisfies the layout constraints
 required by the small code model.
 
 #### Concurrency problems
+
 After the implmentation, I tried JIT linking the CPython interpreter to
 benchmark the implementation. We discovered that our overall CPU execution time
 decreased by 45% but somewhat paradoxically clock time increased by 45%. In
@@ -132,7 +142,6 @@ this to access memory at runtime.
 
 For a more detailed description and all the patches, please consult my
 [GSoC final report](https://compiler-research.org/assets/docs/Anubhab_Ghosh_GSoC2022_Report.pdf).
-
 
 ### Acknowledgements
 
@@ -157,7 +166,7 @@ many applications.
 
 **Contact me!**
 
-Email: anubhabghosh.me@gmail.com
+Email: <anubhabghosh.me@gmail.com>
 
 Github Username: [argentite](https://github.com/argentite)
 

--- a/_posts/2022-12-07-shared-memory-based-jitlink-memory-manager.md
+++ b/_posts/2022-12-07-shared-memory-based-jitlink-memory-manager.md
@@ -166,7 +166,7 @@ many applications.
 
 **Contact me!**
 
-Email: <anubhabghosh.me@gmail.com>
+Email: [anubhabghosh.me@gmail.com](/team/AnubhabGhosh)
 
 Github Username: [argentite](https://github.com/argentite)
 

--- a/_posts/2023-05-10-accelerated-documentation-with-google-season-of-docs-2023.md
+++ b/_posts/2023-05-10-accelerated-documentation-with-google-season-of-docs-2023.md
@@ -11,6 +11,7 @@ sitemap: false
 author: QuillPusher
 permalink: blogs/gsod23_quillpusher_experience_blog/
 date: 2023-05-10
+tags: gsod documentation llvm root clang-repl cppyy
 ---
 
 ### How we got started
@@ -76,8 +77,6 @@ an effort. This project has set me off on a trajectory of self-improvement and
 learning, helping me identify how large, distributed communities work and what
 skills I need to acquire to advance in my career.” – [@QuillPusher] (Saqib)
 
-
-
 [Student Success Stories]: https://compiler-research.org/stories/
 
 [GSoD 2023 Case Study]: https://github.com/compiler-research/compiler-research.github.io/blob/master/assets/docs/gsod_casestudy_2023.pdf
@@ -97,4 +96,3 @@ skills I need to acquire to advance in my career.” – [@QuillPusher] (Saqib)
 [cppyy Enhancements]: https://github.com/compiler-research/CppInterOp/pull/160
 
 [Numba Enhancements]: https://github.com/wlav/cppyy/pull/199
-

--- a/_posts/2023-09-18-code-completion-in-clang-repl.md
+++ b/_posts/2023-09-18-code-completion-in-clang-repl.md
@@ -12,6 +12,7 @@ sitemap: false
 author: Yuquan (Fred) Fu
 permalink: blogs/gsoc23_ffu_experience_blog/
 date: 2023-09-18
+tags: gsoc clang llvm
 ---
 
 ### Overview of the Project
@@ -51,11 +52,10 @@ clang-repl> c.move(<tab>
 If users hit the `<tab`> key at the indicated position, listing all symbols
 would be distracting. It is easy to find out that among all declarations, only
 `c1`, `c2` and `s` are well-typed candidates. So an ideal code completion system
-should be able to filter out results using type information. 
+should be able to filter out results using type information.
 
 The project leverages existing components of Clang/LLVM and aims to provides
 context-aware semantic completion suggestions.
-
 
 ### My Approach
 
@@ -97,7 +97,6 @@ main `ASTContext` to the code completion `ASTContext`.
 <img src="/images/blog/cc1.gif" width="600" />
 
 <img src="/images/blog/cc2.gif" width="600" />
-
 
 ### Future Work
 

--- a/_posts/2024-05-11-llvm-org-website-redesign-project.md
+++ b/_posts/2024-05-11-llvm-org-website-redesign-project.md
@@ -9,13 +9,14 @@ sitemap: false
 author: Chaitanya Shahare
 permalink: blogs/gsoc24_chaitanya_shahare_introduction_blog/
 date: 2024-05-11
+tags: gsoc llvm website
 ---
 
 ### Introduction
 
 I’m Chaitanya Shahare, a passionate full-stack web developer and a pre-final-year
 Mechanical Engineering student at the National Institute of Technology
-Srinagar, India. This summer, I'm delighted to embark on an exciting journey with LLVM as 
+Srinagar, India. This summer, I'm delighted to embark on an exciting journey with LLVM as
 Google Summer of Code 2024 contributor, where I'll be contributing to the LLVM project by
 improving the look and feel of its central hub, the LLVM.org website.
 
@@ -64,7 +65,7 @@ breakdown of how I plan to achieve this:
    which is essential for a website like LLVM.org that is frequently updated
    with new information. This choice ensures that the website can be easily
    maintained and updated by the community, long after the project's
-   completion also ensuring that this project is reusable for other sub-projects 
+   completion also ensuring that this project is reusable for other sub-projects
    websites in the LLVM ecosystem.
 
 3. **Interactive Design Process**: Designing an engaging and user-friendly
@@ -93,13 +94,13 @@ breakdown of how I plan to achieve this:
 
 Through detailed planning, collaborative design, and careful execution, this
 project aims to not only revamp the LLVM.org website but also enhance how the
-LLVM community interacts with it. 
+LLVM community interacts with it.
 
 ### Conclusion
 
 As we start this journey to improve the LLVM.org website, I am excited and
 ready for the challenges ahead. I'm confident we can create a website that
-everyone will find easy to use and helpful. 
+everyone will find easy to use and helpful.
 
 ### Related Links
 


### PR DESCRIPTION

#196 

- Add tags to the blog landing page

![image](https://github.com/compiler-research/compiler-research.github.io/assets/108579856/b8cd5968-276a-4bcf-bf0d-20ea9cc27419)

- Tags are linked to the `/tags` page, allowing users to view all posts associated with a specific tag (e.g.,` /tags/#gsoc`)

![image](https://github.com/compiler-research/compiler-research.github.io/assets/108579856/1187ae45-cc51-4eb1-b217-f393e6f3076c)


- Added tags UI in the blog posts at the end

![image](https://github.com/compiler-research/compiler-research.github.io/assets/108579856/35a12244-9c09-4f33-bf68-40f174c10d3d)
