### PR TITLE
Feat: Add publication landing page

### DIFF
--- a/_data/preslist.yml
+++ b/_data/preslist.yml
@@ -274,7 +274,7 @@
     [Link to Slides](/assets/presentations/G_Singh-MiapbTUM_AD_RooFit.pdf)
   highlight: 1
 
-- title: "Fast and Automatic Floating Point Error Analysis With CHEF-FP"
+- title: "Fast And Automatic Floating Point Error Analysis With CHEF-FP"
   description: |
     As we reach the limit of Moore's Law, researchers are exploring different 
     paradigms to achieve unprecedented performance. Approximate Computing (AC), 

--- a/_data/publist.yml
+++ b/_data/publist.yml
@@ -399,25 +399,6 @@
   url: https://arxiv.org/abs/2304.02650
   year: '2023'
 
-# - title: Fast And Automatic Floating Point Error Analysis With CHEF-FP
-#   author: Garima Singh, Baidyanath Kundu, Harshitha Menon, Alexander Penev, David J. Lange,
-#     Vassil Vassilev
-#   abstract: |
-#     As we reach the limit of Moore's Law, researchers are exploring different paradigms to
-#     achieve unprecedented performance. Approximate Computing (AC), which relies on the ability
-#     of applications to tolerate some error in the results to trade-off accuracy for performance,
-#     has shown significant promise. Despite the success of AC in domains such as Machine Learning,
-#     its acceptance in High-Performance Computing (HPC) is limited due to stringent requirements
-#     for accuracy. We need tools and techniques to identify regions of code that are amenable to
-#     approximations and their impact on the application output quality to guide developers to employ
-#     selective approximation. To this end, we propose CHEF-FP, a flexible, scalable, and easy-to-use
-#     source-code transformation tool based on Automatic Differentiation (AD) for analyzing
-#     approximation errors in HPC applications. CHEF-FP uses ...
-#   cites: '0'
-#   eprint: https://arxiv.org/abs/2304.06441
-#   url: https://arxiv.org/abs/2304.06441
-#   year: '2023'
-
 - title: Efficient and Accurate Automatic Python Bindings with cppyy & Cling
   author: Baidyanath Kundu, Vassil Vassilev, Wim Lavrijsen
   abstract: |

--- a/_data/publist.yml
+++ b/_data/publist.yml
@@ -399,24 +399,24 @@
   url: https://arxiv.org/abs/2304.02650
   year: '2023'
 
-- title: Fast And Automatic Floating Point Error Analysis With CHEF-FP
-  author: Garima Singh, Baidyanath Kundu, Harshitha Menon, Alexander Penev, David J. Lange,
-    Vassil Vassilev
-  abstract: |
-    As we reach the limit of Moore's Law, researchers are exploring different paradigms to
-    achieve unprecedented performance. Approximate Computing (AC), which relies on the ability
-    of applications to tolerate some error in the results to trade-off accuracy for performance,
-    has shown significant promise. Despite the success of AC in domains such as Machine Learning,
-    its acceptance in High-Performance Computing (HPC) is limited due to stringent requirements
-    for accuracy. We need tools and techniques to identify regions of code that are amenable to
-    approximations and their impact on the application output quality to guide developers to employ
-    selective approximation. To this end, we propose CHEF-FP, a flexible, scalable, and easy-to-use
-    source-code transformation tool based on Automatic Differentiation (AD) for analyzing
-    approximation errors in HPC applications. CHEF-FP uses ...
-  cites: '0'
-  eprint: https://arxiv.org/abs/2304.06441
-  url: https://arxiv.org/abs/2304.06441
-  year: '2023'
+# - title: Fast And Automatic Floating Point Error Analysis With CHEF-FP
+#   author: Garima Singh, Baidyanath Kundu, Harshitha Menon, Alexander Penev, David J. Lange,
+#     Vassil Vassilev
+#   abstract: |
+#     As we reach the limit of Moore's Law, researchers are exploring different paradigms to
+#     achieve unprecedented performance. Approximate Computing (AC), which relies on the ability
+#     of applications to tolerate some error in the results to trade-off accuracy for performance,
+#     has shown significant promise. Despite the success of AC in domains such as Machine Learning,
+#     its acceptance in High-Performance Computing (HPC) is limited due to stringent requirements
+#     for accuracy. We need tools and techniques to identify regions of code that are amenable to
+#     approximations and their impact on the application output quality to guide developers to employ
+#     selective approximation. To this end, we propose CHEF-FP, a flexible, scalable, and easy-to-use
+#     source-code transformation tool based on Automatic Differentiation (AD) for analyzing
+#     approximation errors in HPC applications. CHEF-FP uses ...
+#   cites: '0'
+#   eprint: https://arxiv.org/abs/2304.06441
+#   url: https://arxiv.org/abs/2304.06441
+#   year: '2023'
 
 - title: Efficient and Accurate Automatic Python Bindings with cppyy & Cling
   author: Baidyanath Kundu, Vassil Vassilev, Wim Lavrijsen
@@ -486,5 +486,6 @@
   pages: 1018-1028
   publisher: IEEE
   url: https://ieeexplore.ieee.org/document/10177445
+  link: /publications/fast-and-automatic-floating-point-error-analysis-with-chef-fp
   volume: '608'
   year: '2023'

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,0 +1,72 @@
+---
+layout: default
+---
+
+{% assign publication = site.data.publist | where: "title", page.title | first %}
+
+<article class="publication" itemscope itemtype="http://schema.org/ScholarlyArticle">
+  <header class="publication-header">
+    <h1 class="publication-title" itemprop="headline">{{ publication.title }}</h1>
+    <p class="publication-meta">
+      <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+        <span itemprop="name">{{ publication.author }}</span>
+      </span>
+      • <time datetime="{{ publication.year | date: "%Y" }}" itemprop="datePublished">{{ publication.year }}</time>
+    </p>
+  </header>
+
+  {% if page.banner_image %}
+  <div class="post-banner">
+    <img src="{{ page.banner_image }}"
+         alt="Banner Image" class="banner-image" />
+  </div>
+  {% endif %}
+
+  <div class="publication-content" itemprop="description">
+    <h3>Abstract</h3>
+    <p>{{ publication.abstract | markdownify }}</p>
+    {{ content }}
+  </div>
+
+  <div class="publication-info">
+    <h3>Details</h3>
+    {% if publication.journal %}
+      <p><strong>Journal:</strong> {{ publication.journal }}</p>
+    {% endif %}
+    {% if publication.volume %}
+      <p><strong>Volume:</strong> {{ publication.volume }}</p>
+    {% endif %}
+    {% if publication.pages %}
+      <p><strong>Pages:</strong> {{ publication.pages }}</p>
+    {% endif %}
+    {% if publication.cites %}
+      <p><strong>Cited by:</strong> {{ publication.cites }} times</p>
+    {% endif %}
+    {% if publication.eprint %}
+    <p><strong><a href="{{ publication.eprint }}" target="_blank">E-Print</a></strong></p>
+    {% endif %}
+    {% if publication.url %}
+    <p><strong><a href="{{ publication.url }}" target="_blank">Read Full Publication</a></strong></p>
+    {% endif %}
+  </div>
+
+</article>
+
+<style>
+.publication-header .author-image {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.publication-banner .banner-image {
+  width: 100%;
+  height: auto;
+}
+
+.tag-badge {
+  background-color: #999999;
+  padding: 0.5rem;
+}
+</style>

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -3,6 +3,7 @@ layout: default
 ---
 
 {% assign publication = site.data.publist | where: "title", page.title | first %}
+{% assign presentation = site.data.preslist | where: "title", page.title | first %}
 
 <article class="publication" itemscope itemtype="http://schema.org/ScholarlyArticle">
   <header class="publication-header">
@@ -23,36 +24,70 @@ layout: default
   {% endif %}
 
   <div class="publication-content" itemprop="description">
+
     <h3>Abstract</h3>
+
     <p>{{ publication.abstract | markdownify }}</p>
+
+    {% if presentation %}
+    <div class="presentation-info">
+      <h3>Presentation</h3>
+      <div style="display: block; position: relative">
+        <a href="{{ presentation.artifacts | split: '(' | last | strip | split: ')' | first | strip }}">
+          <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/{{ presentation.id }}.gif"
+            class=""
+            style="border-radius:2px; width: 100%;"
+          />
+          <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/{{ presentation.id }}.png"
+            class="gif-animated-static"
+            style="border-radius:2px; width: 100%; position: absolute; top: 0; left: 0; margin; 0"
+          />
+        </a>
+      </div>
+      <p><strong>Title:</strong> {{ presentation.title }}</p>
+      <p><strong>Location:</strong> {{ presentation.location  | markdownify }}</p>
+      <p><strong>Date:</strong> {{ presentation.date | date: "%B %d, %Y" }}</p>
+      <p><strong>Speaker:</strong> {{ presentation.speaker }}</p>
+      <p><strong>Artifacts:</strong> {{ presentation.artifacts | markdownify }}</p>
+
+    </div>
+    {% endif %}
+
     {{ content }}
   </div>
 
   <div class="publication-info">
     <h3>Details</h3>
+
     {% if publication.journal %}
       <p><strong>Journal:</strong> {{ publication.journal }}</p>
     {% endif %}
+
     {% if publication.volume %}
       <p><strong>Volume:</strong> {{ publication.volume }}</p>
     {% endif %}
+
     {% if publication.pages %}
       <p><strong>Pages:</strong> {{ publication.pages }}</p>
     {% endif %}
+
     {% if publication.cites %}
       <p><strong>Cited by:</strong> {{ publication.cites }} times</p>
     {% endif %}
+
     {% if publication.eprint %}
-    <p><strong><a href="{{ publication.eprint }}" target="_blank">E-Print</a></strong></p>
+      <p><strong><a href="{{ publication.eprint }}" target="_blank">E-Print</a></strong></p>
     {% endif %}
+
     {% if publication.url %}
-    <p><strong><a href="{{ publication.url }}" target="_blank">Read Full Publication</a></strong></p>
+      <p><strong><a href="{{ publication.url }}" target="_blank">Read Full Publication</a></strong></p>
     {% endif %}
   </div>
 
 </article>
 
 <style>
+
 .publication-header .author-image {
   width: 30px;
   height: 30px;
@@ -69,4 +104,19 @@ layout: default
   background-color: #999999;
   padding: 0.5rem;
 }
+
+.presentation-info {
+  margin-top: 2rem;
+  border-top: 1px solid #ddd;
+  padding-top: 1rem;
+}
+
+.presentation-info h3 {
+  margin-bottom: 1rem;
+}
+
+.presentation-info p {
+  margin-bottom: 0.5rem;
+}
+
 </style>

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -76,6 +76,11 @@ permalink: /publications/
 {% if  publi.abstract.size  > 7 %} 
   * {{publi.abstract}}
 {% endif %} 
+  {% if publi.link %}
+    <p>
+      <button class="btn btn-primary" onclick="window.location.href='{{ publi.link }}'">Read More</button>
+    </p>
+  {% endif %}
 {% endfor %}
 </div>
 </div>

--- a/_pages/publications/fast-and-automatic-floating-point-error-analysis-withchef-fp.md
+++ b/_pages/publications/fast-and-automatic-floating-point-error-analysis-withchef-fp.md
@@ -4,3 +4,6 @@ permalink: /publications/fast-and-automatic-floating-point-error-analysis-with-c
 layout: publication
 ---
 
+### Tutorial
+
+[How to Estimate Floating Point Errors Using Automatic Differentiation]( https://compiler-research.org/tutorials/fp_error_estimation_clad_tutorial/ )

--- a/_pages/publications/fast-and-automatic-floating-point-error-analysis-withchef-fp.md
+++ b/_pages/publications/fast-and-automatic-floating-point-error-analysis-withchef-fp.md
@@ -1,0 +1,6 @@
+---
+title: Fast And Automatic Floating Point Error Analysis With CHEF-FP
+permalink: /publications/fast-and-automatic-floating-point-error-analysis-with-chef-fp
+layout: publication
+---
+


### PR DESCRIPTION
Fixes #216 

## Changes

1. Add `Read More` button for publications having `link` key in `_data/publist.yml`.

![image](https://github.com/compiler-research/compiler-research.github.io/assets/108579856/e683fc2a-6dae-4c3f-9da0-275ce95bddda)

2. Add `_layouts/publication.html` for the publication landing page layout with `Abstract` and `Details` section by default.

![image](https://github.com/compiler-research/compiler-research.github.io/assets/108579856/cf646392-39b8-412d-b6e3-a2586b367059)

3. We can add a markdown file for the particular publication in `_pages/publication/<title-of-publication>.md` with the front matter similar to the following
    ```yaml
    ---
    title: Title of the Publication
    permalink: /publications/<dash-separated-title>
    layout: publication
    ---
    ```
   - Markdown can be populated for adding additional resources for the publication
   
   - `title` links the page to the `_data/publist.yml` file.
   

    
    

 