### PR TITLE
Fix link for Maksym Andriichuk's weekly presentation

### DIFF
--- a/_data/standing_meetings.yml
+++ b/_data/standing_meetings.yml
@@ -6,7 +6,7 @@
     - title: "Optimizing automatic differentiation using activity analysis"
       date: 2024-06-12 17:00:00 +0200
       speaker: "Maksym Andriichuk"
-      link: "[Slides](assets/presentations/CaaS_Weekly_12_06_2024_Maksym_Andriichuk_Activity.pdf)"
+      link: "[Slides](/assets/presentations/CaaS_Weekly_12_06_2024_Maksym_Andriichuk_Activity.pdf)"
     - title: Updates
       link: "[Meeting Notes](https://docs.google.com/document/d/1HMUtM8rRPeTYDqsWZVD-iQityjJj9_GKgu0FHHbiBr0)"
     - title: "Integrate a large language model with the Xeus-cpp jupyter kernel"


### PR DESCRIPTION
This PR is meant to fix the link to the presentation "Optimizing automatic differentiation using activity analysis".