### PR TITLE
Fix blogs landing page padding

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -3,8 +3,10 @@ layout: default
 title: Blog
 ---
 
-<h2>Latest Posts</h2>
+<div class="col-sm-12">
+  <h2>Latest Posts</h2>
 
-<div>
-  {% for post in site.posts %} {% include blog-post-card.html %} {% endfor %}
+  <div>
+    {% for post in site.posts %} {% include blog-post-card.html %} {% endfor %}
+  </div>
 </div>


### PR DESCRIPTION
fixes #231 
- blogs landing page has padding on small width devices (mobile)
<img width="386" alt="image" src="https://github.com/user-attachments/assets/bb2b4eea-9aea-4596-89d9-6da9b8ae0395">
